### PR TITLE
Position schema requires an address in README sample script

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,14 @@ position = Position.new(
   application_method: application_method,
   attributes: {
     title: 'A title',
-    purpose: 'A purpose'
+    purpose: 'A purpose',
+    address: {
+      country_code: 'SE',
+      zip: '11356',
+      municipality: 'Stockholm',
+      street: 'Birger Jarlsgatan 57',
+      city: 'stockholm'
+    }
   }
 )
 


### PR DESCRIPTION
Executing the sample script in the README results in the following error:

```
~/code/working/jobcentre > ruby jobcentre.rb
salary.valid?: true
schedule.valid?: true
publication.valid?: false
document.valid?: true
company.valid?: true
application_method.valid?: true
position.valid?: false
packet.valid?: true
/var/lib/gems/2.3.0/gems/arbetsformedlingen-0.1.2/lib/arbetsformedlingen/models/position.rb:41:in `fetch': key not found: :address (KeyError)
	from /var/lib/gems/2.3.0/gems/arbetsformedlingen-0.1.2/lib/arbetsformedlingen/models/position.rb:41:in `to_h'
	from /var/lib/gems/2.3.0/gems/arbetsformedlingen-0.1.2/lib/arbetsformedlingen/models/packet.rb:35:in `to_h'
	from /var/lib/gems/2.3.0/gems/arbetsformedlingen-0.1.2/lib/arbetsformedlingen/output_builder.rb:12:in `to_xml'
	from jobcentre.rb:97:in `<main>'
```

It appears that Position requires an Address in it's attributes. This pull request adds that.

Ruby is not my native language, so I hope this PR is both correct and ruby-ish. Let me know if changes are needed.

Also, a huge thank you for posting this! The Arbetsförmedlingen documentation is lacking, and a working implementation to reference saved my sanity.