### PR TITLE
Fix key not found matchningdata, matchningslista

### DIFF
--- a/lib/arbetsformedlingen/api/matchning_client.rb
+++ b/lib/arbetsformedlingen/api/matchning_client.rb
@@ -82,7 +82,7 @@ module Arbetsformedlingen
 
         response = request.get('matchning', query: query)
 
-        MatchningResult.build(response.json)
+        MatchningResult.build(response)
       end
 
       private

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -14,8 +14,14 @@ module Arbetsformedlingen
           total_vacancies_on_page: data.fetch('antal_platserTotal'),
           total_pages: data.fetch('antal_sidor'),
           raw_data: response_data,
-          data: data.fetch('matchningdata').map { |ad_data| build_ad_result(ad_data) }
+          data: build_ad_results(data)
         )
+      end
+
+      def self.build_ad_results(data)
+        data.fetch('matchningdata', []).map do |ad_data|
+          build_ad_result(ad_data)
+        end
       end
 
       def self.build_ad_result(ad_data)

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -3,7 +3,13 @@ require 'arbetsformedlingen/api/values/matchning_result_values'
 module Arbetsformedlingen
   module API
     module MatchningResult
-      def self.build(response_data)
+      def self.build(response)
+        raise Values::MatchningError, response unless response.code == '200'
+
+        build_matchning_page(response.json)
+      end
+
+      def self.build_matchning_page(response_data)
         data = response_data.fetch('matchningslista')
 
         Values::MatchningPage.new(

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -4,12 +4,30 @@ module Arbetsformedlingen
   module API
     module MatchningResult
       def self.build(response)
-        raise Values::MatchningError, response unless response.code == '200'
+        return empty_matchning_page(response) unless response.code == '200'
 
-        build_matchning_page(response.json)
+        build_matchning_page(response)
       end
 
-      def self.build_matchning_page(response_data)
+      def self.empty_matchning_page(response)
+        response_data = response.json
+
+        Values::MatchningPage.new(
+          list_name: 'annonser',
+          total_ads: 0,
+          total_ads_exact: 0,
+          total_ads_nearby: 0,
+          total_vacancies_on_page: 0,
+          total_pages: 0,
+          raw_data: response_data,
+          data: [],
+          response: response,
+          success: false
+        )
+      end
+
+      def self.build_matchning_page(response)
+        response_data = response.json
         data = response_data.fetch('matchningslista')
 
         Values::MatchningPage.new(
@@ -20,7 +38,9 @@ module Arbetsformedlingen
           total_vacancies_on_page: data.fetch('antal_platserTotal'),
           total_pages: data.fetch('antal_sidor'),
           raw_data: response_data,
-          data: build_ad_results(data)
+          data: build_ad_results(data),
+          response: response,
+          success: true
         )
       end
 

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -26,6 +26,13 @@ module Arbetsformedlingen
         end
       end
 
+      # Error thrown when matchning response is invalid
+      class MatchningError < StandardError
+        def initialize(response)
+          super(response.body.gsub(%r{<\/?[^>]*>}, ' ').strip)
+        end
+      end
+
       MatchningAd = KeyStruct.new(
         :id,
         :title,

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -10,7 +10,9 @@ module Arbetsformedlingen
         :total_places_total,
         :total_pages,
         :data,
-        :raw_data
+        :raw_data,
+        :response,
+        :success
       )
       class MatchningPage
         include Enumerable
@@ -24,12 +26,9 @@ module Arbetsformedlingen
           hash[:data].map!(&:to_h)
           hash
         end
-      end
 
-      # Error thrown when matchning response is invalid
-      class MatchningError < StandardError
-        def initialize(response)
-          super(response.body.gsub(%r{<\/?[^>]*>}, ' ').strip)
+        def success?
+          success
         end
       end
 

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -138,7 +138,9 @@ RSpec.describe Arbetsformedlingen::API::Client do
     it 'handles error from arbetsförmedlingen', vcr: true do
       client = described_class.new
 
-      client.ads(county_id: 1, page: 9999, page_size: 1000)
+      expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
+        .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
+                        /Fel vid hämtning av annonslista/)
     end
   end
 

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -126,6 +126,14 @@ RSpec.describe Arbetsformedlingen::API::Client do
       expect(result.country_id).not_to be_nil
       expect(result.employment_type).not_to be_nil
     end
+
+    it 'returns empty list when no results are found', vcr: true do
+      client = described_class.new
+
+      counties = client.ads(municipality_id: '0780', page: 23, page_size: 100)
+
+      expect(counties.data.length).to equal(0)
+    end
   end
 
   describe '#areas', vcr: true do

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
         .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
-                        /Fel vid hämtning av annonslista/)
+                        /Fel vid h.+mtning av annonslista/)
     end
   end
 

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect(counties.data.length).to equal(0)
     end
+
+    it 'handles error from arbetsförmedlingen', vcr: true do
+      client = described_class.new
+
+      client.ads(county_id: 1, page: 9999, page_size: 1000)
+    end
   end
 
   describe '#areas', vcr: true do

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -130,17 +130,24 @@ RSpec.describe Arbetsformedlingen::API::Client do
     it 'returns empty list when no results are found', vcr: true do
       client = described_class.new
 
-      counties = client.ads(municipality_id: '0780', page: 23, page_size: 100)
+      page = client.ads(municipality_id: '0780', page: 23, page_size: 100)
 
-      expect(counties.data.length).to equal(0)
+      expect(page.data.length).to equal(0)
+      expect(page).to be_success
+      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response.code).to eq('200')
     end
 
     it 'handles error from arbetsförmedlingen', vcr: true do
       client = described_class.new
 
-      expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
-        .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
-                        /Fel vid h.+mtning av annonslista/)
+      page = client.ads(county_id: 1, page: 9999, page_size: 1000)
+
+      expect(page.data.length).to equal(0)
+      expect(page).to be_a(Arbetsformedlingen::API::Values::MatchningPage)
+      expect(page).not_to be_success
+      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response.code).to eq('500')
     end
   end
 

--- a/spec/cassettes/Arbetsformedlingen_API_Client/_ads/handles_error_from_arbetsf_rmedlingen.yml
+++ b/spec/cassettes/Arbetsformedlingen_API_Client/_ads/handles_error_from_arbetsf_rmedlingen.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.arbetsformedlingen.se/af/v0/platsannonser/matchning?anstallningstyp&antalrader=1000&kommunid&lanid=1&nyckelord&omradeid&organisationsnummer&sida=9999&sokdatum&yrkesgruppid&yrkesid&yrkesomradeid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.arbetsformedlingen.se
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - sv
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:26:09 GMT
+      Server:
+      - WildFly/8
+      Www-Authenticate:
+      - Basic realm="CT"
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Powered-By:
+      - Undertow/1
+      Access-Control-Allow-Headers:
+      - X-JWT-Assertion, Origin, X-Requested-With, Content-Type, Accept
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '333'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, HEAD, PUT, POST, DELETE
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PGh0bWw+PGhlYWQ+PC9oZWFkPjxib2R5PiA8aDE+RXJyb3I8L2gxPkJlc2tyaXZuaW5nOiBGZWwgdmlkIGjDpG10bmluZyBhdiBhbm5vbnNsaXN0YSBtZWQgc8O2a2tyaXRlcmllcihsYW5pZDoxOyBsYW5kaWQ6OyBvbXJhZGVpZDo7IGtvbW11bmlkOjsgeXJrZXNpZDo7IHlya2VzZ3J1cHBpZDo7IHZhcmFrdGlnaGV0aWQ6OyB5cmtlc29tcmFkZWlkOjsgIG55Y2tlbG9yZDo7IHNpZGE6OTk5OTsgYW50YWxyYWRlcjoxMDAwKTxiciAvPlN0YXR1c2tvZDogSW50ZXJuYWwgU2VydmVyIEVycm9yPGJyIC8+VGl0ZWw6IEludGVybmFsIFNlcnZlciBFcnJvcjxiciAvPjwvYm9keT48L2h0bWw+
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:26:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Arbetsformedlingen_API_Client/_ads/returns_empty_list_when_no_results_are_found.yml
+++ b/spec/cassettes/Arbetsformedlingen_API_Client/_ads/returns_empty_list_when_no_results_are_found.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.arbetsformedlingen.se/af/v0/platsannonser/matchning?anstallningstyp&antalrader=100&kommunid=0780&lanid&nyckelord&omradeid&organisationsnummer&sida=23&sokdatum&yrkesgruppid&yrkesid&yrkesomradeid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.arbetsformedlingen.se
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - sv
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:07:40 GMT
+      Server:
+      - WildFly/8
+      Www-Authenticate:
+      - Basic realm="CT"
+      Cache-Control:
+      - no-transform, max-age=600
+      X-Powered-By:
+      - Undertow/1
+      Access-Control-Allow-Headers:
+      - X-JWT-Assertion, Origin, X-Requested-With, Content-Type, Accept
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept,Accept-Language
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '153'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, HEAD, PUT, POST, DELETE
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"matchningslista":{"antal_platsannonser":662,"antal_platsannonser_exakta":0,"antal_platsannonser_narliggande":0,"antal_platserTotal":0,"antal_sidor":7}}'
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:07:40 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Hey, we noticed two keyerrors when using `client.ads(...)`.

The first one 9c13955 happens when no results are given, and I solved that by defaulting to an empty array.

The second one I'm not sure about, so I started out by just writing a failing test 
6cdc5af.
Error is `KeyError: key not found: "matchningslista"`, and that's because `response.json` gives `{}`.
Response is actually:
```
>#<struct Arbetsformedlingen::API::Request::Response
 code="500",
 body=
  "<html><head></head><body> <h1>Error</h1>Beskrivning: Fel vid hämtning av annonslista med sökkriterier(lanid:1; landid:; omradeid:; kommunid:; yrkesid:; yrkesgruppid:; varaktighetid:; yrkesomradeid:;  nyckelord:; sida:9999; antalrader:1000)<br />Statuskod: Internal Server Error<br
 />Titel: Internal Server Error<br /></body></html>",
 json={}>
```

One possible solution is to raise a better error, here's my attempt 5696764 at that.