### PR TITLE
Handle API response errors and empty results

### DIFF
--- a/lib/arbetsformedlingen/api/client.rb
+++ b/lib/arbetsformedlingen/api/client.rb
@@ -69,7 +69,7 @@ module Arbetsformedlingen
       def areas
         response = request.get('soklista/omrade')
 
-        SoklistaResult.build(response.json, list_name: 'omrade')
+        SoklistaResult.build(response, list_name: 'omrade')
       end
 
       # Fetch counties from API (countries => land)
@@ -81,7 +81,7 @@ module Arbetsformedlingen
         query = { omradeid: area_id }
         response = request.get('soklista/land', query: query)
 
-        SoklistaResult.build(response.json, list_name: 'land')
+        SoklistaResult.build(response, list_name: 'land')
       end
 
       # Fetch municipalities from API (municipality => kommun)
@@ -95,7 +95,7 @@ module Arbetsformedlingen
         query = { lanid: county_id }
         response = request.get('soklista/kommuner', query: query)
 
-        SoklistaResult.build(response.json, list_name: 'kommuner')
+        SoklistaResult.build(response, list_name: 'kommuner')
       end
 
       # Fetch counties from API (county => län)
@@ -105,7 +105,7 @@ module Arbetsformedlingen
       def counties
         response = request.get('soklista/lan')
 
-        SoklistaResult.build(response.json, list_name: 'lan')
+        SoklistaResult.build(response, list_name: 'lan')
       end
 
       # Fetch counties2 from API (county2 => län2)
@@ -115,7 +115,7 @@ module Arbetsformedlingen
       def counties2
         response = request.get('soklista/lan2')
 
-        SoklistaResult.build(response.json, list_name: 'lan2')
+        SoklistaResult.build(response, list_name: 'lan2')
       end
 
       # Fetch occupational fields from API (occupational_fields => yrkesområde)
@@ -125,7 +125,7 @@ module Arbetsformedlingen
       def occupational_fields
         response = request.get('soklista/yrkesomraden')
 
-        SoklistaResult.build(response.json, list_name: 'yrkesomraden')
+        SoklistaResult.build(response, list_name: 'yrkesomraden')
       end
 
       # Fetch occupational group from API (occupational_group => yrkesgrupp)
@@ -141,7 +141,7 @@ module Arbetsformedlingen
         query = { yrkesomradeid: occupational_field_id }
         response = request.get('soklista/yrkesgrupper', query: query)
 
-        SoklistaResult.build(response.json, list_name: 'yrkesgrupper')
+        SoklistaResult.build(response, list_name: 'yrkesgrupper')
       end
 
       # Fetch occupation from API (occupation => yrkesnamn)
@@ -152,7 +152,7 @@ module Arbetsformedlingen
       def occupation(name:)
         response = request.get("soklista/yrken/#{URI.encode(name)}")
 
-        SoklistaResult.build(response.json, list_name: 'Yrken')
+        SoklistaResult.build(response, list_name: 'Yrken')
       end
 
       # Fetch occupations from API (occupation => yrkesnamn)
@@ -168,7 +168,7 @@ module Arbetsformedlingen
         query = { yrkesgruppid: occupational_group_id }
         response = request.get('soklista/yrken', query: query)
 
-        SoklistaResult.build(response.json, list_name: 'yrken')
+        SoklistaResult.build(response, list_name: 'yrken')
       end
     end
   end

--- a/lib/arbetsformedlingen/api/client.rb
+++ b/lib/arbetsformedlingen/api/client.rb
@@ -50,7 +50,7 @@ module Arbetsformedlingen
       def ad(id:)
         response = request.get(id)
 
-        AdResult.build(response.json)
+        AdResult.build(response)
       end
 
       # Fetch ads from API (areas => landområde/värdsdel)

--- a/lib/arbetsformedlingen/api/client.rb
+++ b/lib/arbetsformedlingen/api/client.rb
@@ -14,11 +14,14 @@ require 'arbetsformedlingen/api/ledigtarbete_client'
 
 module Arbetsformedlingen
   module API
+    # Main API client
     class Client
+      # Base URL for platsannonser
       BASE_URL = 'http://api.arbetsformedlingen.se/af/v0/platsannonser/'.freeze
 
       attr_reader :request, :locale
 
+      # Initialize client
       def initialize(locale: 'sv')
         @request = Request.new(base_url: BASE_URL, locale: locale)
         @locale = locale
@@ -33,7 +36,7 @@ module Arbetsformedlingen
       end
 
       # Post ad to API (ad => annons)
-      # @return [AdResult] the result.
+      # @return [Values::CreateAdPage] the result.
       # @param [Arbetsformedlingen::Packet] Packet object.
       # @example Post ad
       #    client.ad(packet)
@@ -43,10 +46,11 @@ module Arbetsformedlingen
       end
 
       # Fetch ad from API (ad => annons)
-      # @return [AdResult] the result.
+      # @return [Values::Ad] the result.
       # @param id [String] Ad ID.
       # @example Get ad
       #    client.ad(id: id)
+      # @see Values::Ad
       def ad(id:)
         response = request.get(id)
 
@@ -54,18 +58,18 @@ module Arbetsformedlingen
       end
 
       # Fetch ads from API (areas => landområde/värdsdel)
-      # @return [MatchningResult] the result.
-      # @see MatchningClient#ads
-      # @see MatchningResult#build
+      # @return [Values::MatchningPage] the result.
+      # @see Values::MatchningPage
       def ads(**args)
         client = MatchningClient.new(request: request)
         client.ads(**args)
       end
 
       # Fetch areas from API (areas => landområde/värdsdel)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @example Get areas
       #    client.areas
+      # @see Values::SoklistaPage
       def areas
         response = request.get('soklista/omrade')
 
@@ -73,10 +77,11 @@ module Arbetsformedlingen
       end
 
       # Fetch counties from API (countries => land)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @param area_id [String] Area ID.
       # @example Get countries within area
       #    client.countries(area_id: id)
+      # @see Values::SoklistaPage
       def countries(area_id:)
         query = { omradeid: area_id }
         response = request.get('soklista/land', query: query)
@@ -85,10 +90,11 @@ module Arbetsformedlingen
       end
 
       # Fetch municipalities from API (municipality => kommun)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @param county_id [String] County ID.
       # @example Get counties
       #    client.counties
+      # @see Values::SoklistaPage
       def municipalities(county_id: nil)
         # NOTE: Due to a quirck in the API the lanid-param
         #       *must* be present though it *can* be nil
@@ -99,9 +105,10 @@ module Arbetsformedlingen
       end
 
       # Fetch counties from API (county => län)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @example Get counties
       #    client.counties
+      # @see Values::SoklistaPage
       def counties
         response = request.get('soklista/lan')
 
@@ -109,9 +116,10 @@ module Arbetsformedlingen
       end
 
       # Fetch counties2 from API (county2 => län2)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @example Get counties2
       #    client.counties2
+      # @see Values::SoklistaPage
       def counties2
         response = request.get('soklista/lan2')
 
@@ -119,9 +127,10 @@ module Arbetsformedlingen
       end
 
       # Fetch occupational fields from API (occupational_fields => yrkesområde)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @example Get occupational fields
       #    client.occupational_field
+      # @see Values::SoklistaPage
       def occupational_fields
         response = request.get('soklista/yrkesomraden')
 
@@ -129,12 +138,13 @@ module Arbetsformedlingen
       end
 
       # Fetch occupational group from API (occupational_group => yrkesgrupp)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @param occupational_field_id [String] Occupational field ID.
       # @example Get all occupational group
       #    client.occupational_group
       # @example Get occupational group within occupational field
       #    client.occupational_group(occupational_field_id: id)
+      # @see Values::SoklistaPage
       def occupational_group(occupational_field_id: nil)
         # NOTE: Due to a quirck in the API the yrkesomradeid-param
         #       *must* be present though it *can* be nil
@@ -145,10 +155,11 @@ module Arbetsformedlingen
       end
 
       # Fetch occupation from API (occupation => yrkesnamn)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @param name [String] Name of the occupation.
       # @example Get occupation
       #    client.occupation(name: 'Marknadskommunikatör')
+      # @see Values::SoklistaPage
       def occupation(name:)
         response = request.get("soklista/yrken/#{URI.encode(name)}")
 
@@ -156,12 +167,13 @@ module Arbetsformedlingen
       end
 
       # Fetch occupations from API (occupation => yrkesnamn)
-      # @return [AdResult] the result.
+      # @return [Values::SoklistaPage] the result.
       # @param occupational_group_id [String] Occupational group ID.
       # @example Get stats of available positions for all occupations
       #    client.occupations
       # @example Get stats of available positions for some occupations
       #    client.occupations(occupational_group_id: id)
+      # @see Values::SoklistaPage
       def occupations(occupational_group_id: nil)
         # NOTE: Due to a quirck in the API the yrkesgruppid-param
         #       *must* be present though it *can* be nil

--- a/lib/arbetsformedlingen/api/ledigtarbete_client.rb
+++ b/lib/arbetsformedlingen/api/ledigtarbete_client.rb
@@ -3,9 +3,12 @@ require 'arbetsformedlingen/api/values/create_ad_page'
 
 module Arbetsformedlingen
   module API
+    # API client for ledigtarbete
     class LedigtarbeteClient
+      # Base URL for ledigtarbete
       BASE_URL = 'http://api.arbetsformedlingen.se/ledigtarbete'.freeze
 
+      # HTTP headers
       HEADERS = {
         'Content-type' => 'text/xml'
       }.freeze

--- a/lib/arbetsformedlingen/api/matchning_client.rb
+++ b/lib/arbetsformedlingen/api/matchning_client.rb
@@ -82,7 +82,7 @@ module Arbetsformedlingen
 
         response = request.get('matchning', query: query)
 
-        MatchningResult.build(response.json)
+        MatchningResult.build(response)
       end
 
       private

--- a/lib/arbetsformedlingen/api/matchning_client.rb
+++ b/lib/arbetsformedlingen/api/matchning_client.rb
@@ -5,9 +5,11 @@ require 'arbetsformedlingen/api/results/matchning_result'
 
 module Arbetsformedlingen
   module API
+    # API client for matchning
     class MatchningClient
       attr_reader :request
 
+      # Initialize client
       def initialize(request: Request.new)
         @request = request
       end

--- a/lib/arbetsformedlingen/api/request.rb
+++ b/lib/arbetsformedlingen/api/request.rb
@@ -1,12 +1,11 @@
 require 'uri'
 require 'net/http'
 require 'json'
+require 'arbetsformedlingen/api/response'
 
 module Arbetsformedlingen
   module API
     class Request
-      Response = KeyStruct.new(:code, :body, :json)
-
       attr_reader :locale, :base_url
 
       def initialize(base_url: '', locale: 'sv')
@@ -25,17 +24,7 @@ module Arbetsformedlingen
 
         response = http.request(request)
 
-        Response.new(
-          code: response.code,
-          body: response.read_body,
-          json: parse_json(response.read_body)
-        )
-      end
-
-      def parse_json(string)
-        JSON.parse(string.to_s)
-      rescue JSON::ParserError => _e
-        {}
+        Response.new(response)
       end
     end
   end

--- a/lib/arbetsformedlingen/api/request.rb
+++ b/lib/arbetsformedlingen/api/request.rb
@@ -5,14 +5,20 @@ require 'arbetsformedlingen/api/response'
 
 module Arbetsformedlingen
   module API
+    # API request object
     class Request
       attr_reader :locale, :base_url
 
+      # Initialize request
       def initialize(base_url: '', locale: 'sv')
         @base_url = base_url
         @locale = locale
       end
 
+      # Perform GEt request
+      # @param [String] url to be fetched
+      # @param [Hash] query params
+      # @return [Response] response object
       def get(url, query: {})
         uri = URI("#{base_url}#{url}?#{URI.encode_www_form(query.to_a)}")
 

--- a/lib/arbetsformedlingen/api/response.rb
+++ b/lib/arbetsformedlingen/api/response.rb
@@ -1,3 +1,8 @@
+begin
+  require 'nokogiri'
+rescue LoadError
+end
+
 module Arbetsformedlingen
   module API
     # API response object
@@ -21,9 +26,15 @@ module Arbetsformedlingen
       end
 
       # Response JSON
-      # @return [Hash] response json Hash, empty is JSON is invalid
+      # @return [Hash] response json - empty if JSON is invalid
       def json
         @json ||= parse_json(body)
+      end
+
+      # Response XML
+      # @return [Nokogiri::XML::Document] response - empty is XML is invalid
+      def xml
+        @xml ||= parse_xml(body)
       end
 
       # Delegate missing values to response
@@ -48,6 +59,10 @@ module Arbetsformedlingen
         JSON.parse(string.to_s)
       rescue JSON::ParserError => _e
         {}
+      end
+
+      def parse_xml(string)
+        Nokogiri::XML(string).tap { |doc| doc.remove_namespaces! }
       end
     end
   end

--- a/lib/arbetsformedlingen/api/response.rb
+++ b/lib/arbetsformedlingen/api/response.rb
@@ -1,0 +1,44 @@
+module Arbetsformedlingen
+  module API
+    class Response
+      def initialize(response)
+        @response = response
+        @json = nil
+      end
+
+      def success?
+        response.code == '200'
+      end
+
+      def body
+        response.read_body
+      end
+
+      def json
+        @json ||= parse_json(body)
+      end
+
+      def method_missing(method_name, *arguments, &block)
+        if response.respond_to?(method_name)
+          response.public_send(method_name, *arguments, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        response.respond_to?(method_name) || super
+      end
+
+      private
+
+      attr_reader :response
+
+      def parse_json(string)
+        JSON.parse(string.to_s)
+      rescue JSON::ParserError => _e
+        {}
+      end
+    end
+  end
+end

--- a/lib/arbetsformedlingen/api/response.rb
+++ b/lib/arbetsformedlingen/api/response.rb
@@ -1,23 +1,32 @@
 module Arbetsformedlingen
   module API
+    # API response object
     class Response
+      # Initialize response
       def initialize(response)
         @response = response
         @json = nil
       end
 
+      # True if response is 200
+      # @return [Boolean] true if response code is 200
       def success?
         response.code == '200'
       end
 
+      # Response body
+      # @return [String] the response body
       def body
         response.read_body
       end
 
+      # Response JSON
+      # @return [Hash] response json Hash, empty is JSON is invalid
       def json
         @json ||= parse_json(body)
       end
 
+      # Delegate missing values to response
       def method_missing(method_name, *arguments, &block)
         if response.respond_to?(method_name)
           response.public_send(method_name, *arguments, &block)
@@ -26,6 +35,7 @@ module Arbetsformedlingen
         end
       end
 
+      # Return true if missing method can be delegated
       def respond_to_missing?(method_name, include_private = false)
         response.respond_to?(method_name) || super
       end

--- a/lib/arbetsformedlingen/api/results/ad_result.rb
+++ b/lib/arbetsformedlingen/api/results/ad_result.rb
@@ -3,7 +3,11 @@ require 'arbetsformedlingen/api/values/ad_result_values'
 module Arbetsformedlingen
   module API
     module AdResult
-      def self.build(response_data)
+      # Build API result object for ad result
+      # @param [API::Response] response
+      # @return [Values::Ad]
+      def self.build(response)
+        response_data = response.json
         data = response_data.fetch('platsannons')
 
         ad_data = data.fetch('annons')
@@ -24,9 +28,12 @@ module Arbetsformedlingen
           terms: build_terms(data.fetch('villkor')),
           application: build_application(data.fetch('ansokan')),
           workplace: build_workplace(data.fetch('arbetsplats')),
-          requirements: build_requirements(data.fetch('krav'))
+          requirements: build_requirements(data.fetch('krav')),
+          response: response
         )
       end
+
+      # private
 
       def self.build_terms(data)
         Values::Terms.new(

--- a/lib/arbetsformedlingen/api/results/ad_result.rb
+++ b/lib/arbetsformedlingen/api/results/ad_result.rb
@@ -43,21 +43,21 @@ module Arbetsformedlingen
 
       def self.build_terms(data)
         Values::Terms.new(
-          duration: data.fetch('varaktighet'),
-          working_hours: data.fetch('arbetstid'),
-          working_hours_description: data.fetch('arbetstidvaraktighet'),
+          duration: data.fetch('varaktighet', nil),
+          working_hours: data.fetch('arbetstid', nil),
+          working_hours_description: data.fetch('arbetstidvaraktighet', nil),
           salary_type: data.fetch('lonetyp'),
-          salary_form: data.fetch('loneform')
+          salary_form: data.fetch('loneform', nil)
         )
       end
 
       def self.build_application(data)
         Values::Application.new(
           reference: data['referens'],
-          application_url: data.fetch('webbplats'),
+          application_url: data.fetch('webbplats', nil),
           email: data['epostadress'],
           last_application_at: data.fetch('sista_ansokningsdag', nil),
-          application_comment: data.fetch('ovrigt_om_ansokan')
+          application_comment: data.fetch('ovrigt_om_ansokan', nil)
         )
       end
 
@@ -67,8 +67,8 @@ module Arbetsformedlingen
           postal: build_postal(data),
           country: data.fetch('land'),
           visit_address: data.fetch('besoksadress'),
-          logotype_url: data.fetch('logotypurl'),
-          website: data.fetch('hemsida'),
+          logotype_url: data.fetch('logotypurl', nil),
+          website: data.fetch('hemsida', nil),
           contacts: (
             data.dig('kontaktpersonlista', 'kontaktpersonlista') || []
           ).map do |contact_data|

--- a/lib/arbetsformedlingen/api/results/ad_result.rb
+++ b/lib/arbetsformedlingen/api/results/ad_result.rb
@@ -7,6 +7,8 @@ module Arbetsformedlingen
       # @param [API::Response] response
       # @return [Values::Ad]
       def self.build(response)
+        return build_empty(response) unless response.success?
+
         response_data = response.json
         data = response_data.fetch('platsannons')
 
@@ -34,6 +36,10 @@ module Arbetsformedlingen
       end
 
       # private
+
+      def self.build_empty(response)
+        Values::Ad.new(response: response)
+      end
 
       def self.build_terms(data)
         Values::Terms.new(

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -4,7 +4,7 @@ module Arbetsformedlingen
   module API
     module MatchningResult
       def self.build(response)
-        return empty_matchning_page(response) unless response.code == '200'
+        return empty_matchning_page(response) unless response.success?
 
         build_matchning_page(response)
       end
@@ -21,8 +21,7 @@ module Arbetsformedlingen
           total_pages: 0,
           raw_data: response_data,
           data: [],
-          response: response,
-          success: false
+          response: response
         )
       end
 
@@ -39,10 +38,11 @@ module Arbetsformedlingen
           total_pages: data.fetch('antal_sidor'),
           raw_data: response_data,
           data: build_ad_results(data),
-          response: response,
-          success: true
+          response: response
         )
       end
+
+      # private
 
       def self.build_ad_results(data)
         data.fetch('matchningdata', []).map do |ad_data|

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -9,6 +9,8 @@ module Arbetsformedlingen
         build_matchning_page(response)
       end
 
+      # private
+
       def self.empty_matchning_page(response)
         response_data = response.json
 

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -3,6 +3,9 @@ require 'arbetsformedlingen/api/values/matchning_result_values'
 module Arbetsformedlingen
   module API
     module MatchningResult
+      # Build API result object for matchning result
+      # @param [API::Response] response
+      # @return [Values::MatchningPage]
       def self.build(response)
         return empty_matchning_page(response) unless response.success?
 

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -14,8 +14,14 @@ module Arbetsformedlingen
           total_vacancies_on_page: data.fetch('antal_platserTotal'),
           total_pages: data.fetch('antal_sidor'),
           raw_data: response_data,
-          data: data.fetch('matchningdata').map { |ad_data| build_ad_result(ad_data) }
+          data: build_ad_results(data)
         )
+      end
+
+      def self.build_ad_results(data)
+        data.fetch('matchningdata', []).map do |ad_data|
+          build_ad_result(ad_data)
+        end
       end
 
       def self.build_ad_result(ad_data)

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -3,7 +3,13 @@ require 'arbetsformedlingen/api/values/matchning_result_values'
 module Arbetsformedlingen
   module API
     module MatchningResult
-      def self.build(response_data)
+      def self.build(response)
+        raise Values::MatchningError, response unless response.code == '200'
+
+        build_matchning_page(response.json)
+      end
+
+      def self.build_matchning_page(response_data)
         data = response_data.fetch('matchningslista')
 
         Values::MatchningPage.new(

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -4,12 +4,30 @@ module Arbetsformedlingen
   module API
     module MatchningResult
       def self.build(response)
-        raise Values::MatchningError, response unless response.code == '200'
+        return empty_matchning_page(response) unless response.code == '200'
 
-        build_matchning_page(response.json)
+        build_matchning_page(response)
       end
 
-      def self.build_matchning_page(response_data)
+      def self.empty_matchning_page(response)
+        response_data = response.json
+
+        Values::MatchningPage.new(
+          list_name: 'annonser',
+          total_ads: 0,
+          total_ads_exact: 0,
+          total_ads_nearby: 0,
+          total_vacancies_on_page: 0,
+          total_pages: 0,
+          raw_data: response_data,
+          data: [],
+          response: response,
+          success: false
+        )
+      end
+
+      def self.build_matchning_page(response)
+        response_data = response.json
         data = response_data.fetch('matchningslista')
 
         Values::MatchningPage.new(
@@ -20,7 +38,9 @@ module Arbetsformedlingen
           total_vacancies_on_page: data.fetch('antal_platserTotal'),
           total_pages: data.fetch('antal_sidor'),
           raw_data: response_data,
-          data: build_ad_results(data)
+          data: build_ad_results(data),
+          response: response,
+          success: true
         )
       end
 

--- a/lib/arbetsformedlingen/api/results/soklista_result.rb
+++ b/lib/arbetsformedlingen/api/results/soklista_result.rb
@@ -3,7 +3,28 @@ require 'arbetsformedlingen/api/values/soklista_values'
 module Arbetsformedlingen
   module API
     module SoklistaResult
-      def self.build(response_data, list_name: nil)
+      def self.build(response, list_name: nil)
+        return build_empty_page(response, list_name) unless response.success?
+
+        build_page(response, list_name)
+      end
+
+      # private
+
+      def self.build_empty_page(response, list_name)
+        response_data = response.json
+        Values::SoklistaPage.new(
+          list_name: list_name,
+          total_ads: 0,
+          total_vacancies: 0,
+          raw_data: response_data,
+          data: [],
+          response: response
+        )
+      end
+
+      def self.build_page(response, list_name)
+        response_data = response.json
         data = response_data.fetch('soklista', {})
 
         Values::SoklistaPage.new(
@@ -13,7 +34,8 @@ module Arbetsformedlingen
           raw_data: response_data,
           data: data.fetch('sokdata', []).map do |result|
             build_search_result(result)
-          end
+          end,
+          response: response
         )
       end
 

--- a/lib/arbetsformedlingen/api/results/soklista_result.rb
+++ b/lib/arbetsformedlingen/api/results/soklista_result.rb
@@ -3,6 +3,10 @@ require 'arbetsformedlingen/api/values/soklista_values'
 module Arbetsformedlingen
   module API
     module SoklistaResult
+      # Build API result object for "soklista"
+      # @param [API::Response] response
+      # @param list_name [String] result list name
+      # @return [Values::SoklistaPage]
       def self.build(response, list_name: nil)
         return build_empty_page(response, list_name) unless response.success?
 

--- a/lib/arbetsformedlingen/api/soap_request.rb
+++ b/lib/arbetsformedlingen/api/soap_request.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'net/http'
+require 'arbetsformedlingen/api/response'
 
 begin
   require 'nokogiri'
@@ -11,7 +12,7 @@ module Arbetsformedlingen
     # API SOAP request
     class SOAPRequest
       # SOAP response
-      Response = KeyStruct.new(:code, :body, :xml)
+      # Response = KeyStruct.new(:code, :body, :xml)
 
       attr_reader :locale, :uri, :url
 
@@ -40,15 +41,7 @@ module Arbetsformedlingen
 
         response = http.request(request)
 
-        Response.new(
-          code: response.code,
-          body: response.read_body,
-          xml: parse_xml(response.read_body)
-        )
-      end
-
-      def parse_xml(string)
-        Nokogiri::XML(string).tap { |doc| doc.remove_namespaces! }
+        Response.new(response)
       end
     end
   end

--- a/lib/arbetsformedlingen/api/soap_request.rb
+++ b/lib/arbetsformedlingen/api/soap_request.rb
@@ -8,11 +8,14 @@ end
 
 module Arbetsformedlingen
   module API
+    # API SOAP request
     class SOAPRequest
+      # SOAP response
       Response = KeyStruct.new(:code, :body, :xml)
 
       attr_reader :locale, :uri, :url
 
+      # Initialize SOAP request
       def initialize(url, locale: nil)
         unless Object.const_defined?(:Nokogiri)
           raise(ArgumentError, "unable to require 'nokogiri' gem, please install it")
@@ -23,6 +26,9 @@ module Arbetsformedlingen
         @locale = locale
       end
 
+      # Performs a POST request
+      # @param [String] the post body
+      # @return [Response] the response
       def post(body)
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true if uri.scheme == 'https'

--- a/lib/arbetsformedlingen/api/values/ad_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/ad_result_values.rb
@@ -17,7 +17,8 @@ module Arbetsformedlingen
         :terms,
         :application,
         :workplace,
-        :requirements
+        :requirements,
+        :response
       )
       class Ad
         def to_h

--- a/lib/arbetsformedlingen/api/values/ad_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/ad_result_values.rb
@@ -23,6 +23,7 @@ module Arbetsformedlingen
       class Ad
         def to_h
           hash = super.to_h
+          hash.delete(:response) # we don't want to return the raw response object
           hash[:terms] = hash[:terms].to_h
           hash[:application] = hash[:application].to_h
           hash[:workplace] = hash[:workplace].to_h

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -22,6 +22,7 @@ module Arbetsformedlingen
 
         def to_h
           hash = super.to_h
+          hash.delete(:response) # we don't want to return the raw response object
           hash[:data].map!(&:to_h)
           hash
         end

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -26,6 +26,13 @@ module Arbetsformedlingen
         end
       end
 
+      # Error thrown when matchning response is invalid
+      class MatchningError < StandardError
+        def initialize(response)
+          super(response.body.gsub(%r{<\/?[^>]*>}, ' ').strip)
+        end
+      end
+
       MatchningAd = KeyStruct.new(
         :id,
         :title,

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -11,8 +11,7 @@ module Arbetsformedlingen
         :total_pages,
         :data,
         :raw_data,
-        :response,
-        :success
+        :response
       )
       class MatchningPage
         include Enumerable

--- a/lib/arbetsformedlingen/api/values/matchning_result_values.rb
+++ b/lib/arbetsformedlingen/api/values/matchning_result_values.rb
@@ -10,7 +10,9 @@ module Arbetsformedlingen
         :total_places_total,
         :total_pages,
         :data,
-        :raw_data
+        :raw_data,
+        :response,
+        :success
       )
       class MatchningPage
         include Enumerable
@@ -24,12 +26,9 @@ module Arbetsformedlingen
           hash[:data].map!(&:to_h)
           hash
         end
-      end
 
-      # Error thrown when matchning response is invalid
-      class MatchningError < StandardError
-        def initialize(response)
-          super(response.body.gsub(%r{<\/?[^>]*>}, ' ').strip)
+        def success?
+          success
         end
       end
 

--- a/lib/arbetsformedlingen/api/values/soklista_values.rb
+++ b/lib/arbetsformedlingen/api/values/soklista_values.rb
@@ -18,6 +18,7 @@ module Arbetsformedlingen
 
         def to_h
           hash = super.to_h
+          hash.delete(:response) # we don't want to return the raw response object
           hash[:data].map!(&:to_h)
           hash
         end

--- a/lib/arbetsformedlingen/api/values/soklista_values.rb
+++ b/lib/arbetsformedlingen/api/values/soklista_values.rb
@@ -6,7 +6,8 @@ module Arbetsformedlingen
         :total_ads,
         :total_vacancies,
         :data,
-        :raw_data
+        :raw_data,
+        :response
       )
       class SoklistaPage
         include Enumerable
@@ -19,6 +20,18 @@ module Arbetsformedlingen
           hash = super.to_h
           hash[:data].map!(&:to_h)
           hash
+        end
+
+        def method_missing(method_name, *arguments, &block)
+          if response.respond_to?(method_name)
+            response.public_send(method_name, *arguments, &block)
+          else
+            super
+          end
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          response.respond_to?(method_name) || super
         end
       end
 

--- a/lib/arbetsformedlingen/api/ws_occupation_client.rb
+++ b/lib/arbetsformedlingen/api/ws_occupation_client.rb
@@ -3,13 +3,16 @@ require 'arbetsformedlingen/api/soap_request'
 
 module Arbetsformedlingen
   module API
+    # WsOccupation API client
     class WSOccupationClient
       attr_reader :request
 
+      # Service URL
       SERVICE_URL = 'https://api.arbetsformedlingen.se/af/v0/Occupation/wsoccupation.asmx'.freeze
 
+      # Initialize client
       def initialize
-        @request = request || SOAPRequest.new(SERVICE_URL)
+        @request = SOAPRequest.new(SERVICE_URL)
       end
 
       def occupation(id)

--- a/lib/arbetsformedlingen/api/ws_occupation_client.rb
+++ b/lib/arbetsformedlingen/api/ws_occupation_client.rb
@@ -15,6 +15,10 @@ module Arbetsformedlingen
         @request = SOAPRequest.new(SERVICE_URL)
       end
 
+      # Returns occupation response with specified id
+      # @return [Response] the response
+      # @see Response
+      # @see Response#xml
       def occupation(id)
         soap_body = SOAPBuilder.wrap do |body|
           body.GetOccupationById(xmlns: 'urn:ams.se:wsoccupation') do |node|
@@ -25,6 +29,10 @@ module Arbetsformedlingen
         request.post(soap_body.to_xml)
       end
 
+      # Returns occupations response with specified name
+      # @return [Response] the response
+      # @see Response
+      # @see Response#xml
       def find_occupations(name)
         soap_body = SOAPBuilder.wrap do |body|
           body.FindOccupation(xmlns: 'urn:ams.se:wsoccupation') do |node|
@@ -35,6 +43,10 @@ module Arbetsformedlingen
         request.post(soap_body.to_xml)
       end
 
+      # Returns occupations response
+      # @return [Response] the response
+      # @see Response
+      # @see Response#xml
       def occupations
         soap_body = SOAPBuilder.wrap do |body|
           body.GetAllOccupations(xmlns: 'urn:ams.se:wsoccupation')
@@ -43,6 +55,10 @@ module Arbetsformedlingen
         request.post(soap_body.to_xml)
       end
 
+      # Returns occupations short response with specified id
+      # @return [Response] the response
+      # @see Response
+      # @see Response#xml
       def occupations_short
         soap_body = SOAPBuilder.wrap do |body|
           body.GetAllOccupationsShort(xmlns: 'urn:ams.se:wsoccupation')
@@ -51,6 +67,10 @@ module Arbetsformedlingen
         request.post(soap_body.to_xml)
       end
 
+      # Returns occupations detailed response with specified id
+      # @return [Response] the response
+      # @see Response
+      # @see Response#xml
       def occupations_detailed
         soap_body = SOAPBuilder.wrap do |body|
           body.GetAllOccupationsDetailed(xmlns: 'urn:ams.se:wsoccupation')

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect(page.data.length).to equal(0)
       expect(page).to be_a(Arbetsformedlingen::API::Values::MatchningPage)
-      expect(page).not_to be_success
+      expect(page.response).not_to be_success
       expect(page.response).to be_a(Arbetsformedlingen::API::Response)
       expect(page.response.code).to eq('500')
     end

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -138,7 +138,9 @@ RSpec.describe Arbetsformedlingen::API::Client do
     it 'handles error from arbetsförmedlingen', vcr: true do
       client = described_class.new
 
-      client.ads(county_id: 1, page: 9999, page_size: 1000)
+      expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
+        .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
+                        /Fel vid hämtning av annonslista/)
     end
   end
 

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -126,6 +126,14 @@ RSpec.describe Arbetsformedlingen::API::Client do
       expect(result.country_id).not_to be_nil
       expect(result.employment_type).not_to be_nil
     end
+
+    it 'returns empty list when no results are found', vcr: true do
+      client = described_class.new
+
+      counties = client.ads(municipality_id: '0780', page: 23, page_size: 100)
+
+      expect(counties.data.length).to equal(0)
+    end
   end
 
   describe '#areas', vcr: true do

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -133,9 +133,8 @@ RSpec.describe Arbetsformedlingen::API::Client do
       page = client.ads(municipality_id: '0780', page: 23, page_size: 100)
 
       expect(page.data.length).to equal(0)
-      expect(page).to be_success
       expect(page.response).to be_a(Arbetsformedlingen::API::Response)
-      expect(page.response.code).to eq('200')
+      expect(page.response.success?).to eq(true)
     end
 
     it 'handles error from arbetsförmedlingen', vcr: true do

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
         .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
-                        /Fel vid hämtning av annonslista/)
+                        /Fel vid h.+mtning av annonslista/)
     end
   end
 

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
   describe '#create_ad', vcr: true do
     it 'returns error if passed empty data' do
       client = described_class.new
-      data = Struct.new(:to_xml).new('')
+      data = double(to_xml: '')
       response = client.create_ad(data)
 
       expect(response.valid?).to eq(false)

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect(page.data.length).to equal(0)
       expect(page).to be_success
-      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response).to be_a(Arbetsformedlingen::API::Response)
       expect(page.response.code).to eq('200')
     end
 
@@ -146,7 +146,7 @@ RSpec.describe Arbetsformedlingen::API::Client do
       expect(page.data.length).to equal(0)
       expect(page).to be_a(Arbetsformedlingen::API::Values::MatchningPage)
       expect(page).not_to be_success
-      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response).to be_a(Arbetsformedlingen::API::Response)
       expect(page.response.code).to eq('500')
     end
   end

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe Arbetsformedlingen::API::Client do
 
       expect(counties.data.length).to equal(0)
     end
+
+    it 'handles error from arbetsförmedlingen', vcr: true do
+      client = described_class.new
+
+      client.ads(county_id: 1, page: 9999, page_size: 1000)
+    end
   end
 
   describe '#areas', vcr: true do

--- a/spec/arbetsformedlingen/api/client_spec.rb
+++ b/spec/arbetsformedlingen/api/client_spec.rb
@@ -130,17 +130,24 @@ RSpec.describe Arbetsformedlingen::API::Client do
     it 'returns empty list when no results are found', vcr: true do
       client = described_class.new
 
-      counties = client.ads(municipality_id: '0780', page: 23, page_size: 100)
+      page = client.ads(municipality_id: '0780', page: 23, page_size: 100)
 
-      expect(counties.data.length).to equal(0)
+      expect(page.data.length).to equal(0)
+      expect(page).to be_success
+      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response.code).to eq('200')
     end
 
     it 'handles error from arbetsförmedlingen', vcr: true do
       client = described_class.new
 
-      expect { client.ads(county_id: 1, page: 9999, page_size: 1000) }
-        .to raise_error(Arbetsformedlingen::API::Values::MatchningError,
-                        /Fel vid h.+mtning av annonslista/)
+      page = client.ads(county_id: 1, page: 9999, page_size: 1000)
+
+      expect(page.data.length).to equal(0)
+      expect(page).to be_a(Arbetsformedlingen::API::Values::MatchningPage)
+      expect(page).not_to be_success
+      expect(page.response).to be_a(Arbetsformedlingen::API::Request::Response)
+      expect(page.response.code).to eq('500')
     end
   end
 

--- a/spec/arbetsformedlingen/api/response_spec.rb
+++ b/spec/arbetsformedlingen/api/response_spec.rb
@@ -5,13 +5,13 @@ require 'arbetsformedlingen/api/response'
 RSpec.describe Arbetsformedlingen::API::Response do
   describe '#success?' do
     it 'returns true when response code is 200' do
-      response = described_class.new(Struct.new(:code).new('200'))
+      response = described_class.new(double(code: '200'))
 
       expect(response.success?).to eq(true)
     end
 
     it 'returns false when response code is 500' do
-      response = described_class.new(Struct.new(:code).new('500'))
+      response = described_class.new(double(code: '500'))
 
       expect(response.success?).to eq(false)
     end
@@ -19,13 +19,13 @@ RSpec.describe Arbetsformedlingen::API::Response do
 
   context 'delegates missing' do
     it 'returns response value' do
-      response = described_class.new(Struct.new(:some_method).new(true))
+      response = described_class.new(double(some_method: true))
 
       expect(response.some_method).to eq(true)
     end
 
     it 'raises when no method does not exist on response' do
-      response = described_class.new(Struct.new(:some_method).new(true))
+      response = described_class.new(double(some_method: true))
 
       expect do
         response.other_method
@@ -35,7 +35,7 @@ RSpec.describe Arbetsformedlingen::API::Response do
 
   context 'xml' do
     it 'returns a Nokogiri document' do
-      request = described_class.new(Struct.new(:read_body).new(''))
+      request = described_class.new(double(read_body: ''))
       expect(request.xml).to be_a(Nokogiri::XML::Document)
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Arbetsformedlingen::API::Response do
       </soap:Envelope>
       XMLDATA
 
-      request = described_class.new(Struct.new(:read_body).new(xml_with_namespace))
+      request = described_class.new(double(read_body: xml_with_namespace))
 
       document = request.xml
       result = document.css('Id').map(&:text)

--- a/spec/arbetsformedlingen/api/response_spec.rb
+++ b/spec/arbetsformedlingen/api/response_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+require 'arbetsformedlingen/api/response'
+
+RSpec.describe Arbetsformedlingen::API::Response do
+  describe '#success?' do
+    it 'returns true when response code is 200' do
+      response = described_class.new(Struct.new(:code).new('200'))
+
+      expect(response.success?).to eq(true)
+    end
+
+    it 'returns false when response code is 500' do
+      response = described_class.new(Struct.new(:code).new('500'))
+
+      expect(response.success?).to eq(false)
+    end
+  end
+
+  context 'delegates missing' do
+    it 'returns response value' do
+      response = described_class.new(Struct.new(:some_method).new(true))
+
+      expect(response.some_method).to eq(true)
+    end
+
+    it 'raises when no method does not exist on response' do
+      response = described_class.new(Struct.new(:some_method).new(true))
+
+      expect do
+        response.other_method
+      end.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/arbetsformedlingen/api/response_spec.rb
+++ b/spec/arbetsformedlingen/api/response_spec.rb
@@ -32,4 +32,35 @@ RSpec.describe Arbetsformedlingen::API::Response do
       end.to raise_error(NoMethodError)
     end
   end
+
+  context 'xml' do
+    it 'returns a Nokogiri document' do
+      request = described_class.new(Struct.new(:read_body).new(''))
+      expect(request.xml).to be_a(Nokogiri::XML::Document)
+    end
+
+    it 'returns a Nokogiri document with namespaces removed' do
+      xml_with_namespace = <<~XMLDATA
+      <?xml version="1.0" encoding="utf-8"?>
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+        <soap:Body>
+          <GetAllOccupationsShortResponse xmlns="urn:ams.se:wsoccupation">
+            <OccupationsShort>
+              <OccupationShort>
+                <Id>718</Id>
+                <Name>Landskapsarkitekter och landskapsingenjörer</Name>
+              </OccupationShort>
+            </OccupationsShort>
+          </GetAllOccupationsShortResponse>
+        </soap:Body>
+      </soap:Envelope>
+      XMLDATA
+
+      request = described_class.new(Struct.new(:read_body).new(xml_with_namespace))
+
+      document = request.xml
+      result = document.css('Id').map(&:text)
+      expect(result).to eq(%w[718])
+    end
+  end
 end

--- a/spec/arbetsformedlingen/api/soap_request_spec.rb
+++ b/spec/arbetsformedlingen/api/soap_request_spec.rb
@@ -13,35 +13,4 @@ RSpec.describe Arbetsformedlingen::API::SOAPRequest do
       expect { described_class.new('') }.not_to raise_error(ArgumentError)
     end
   end
-
-  describe '#parse_xml' do
-    it 'returns a Nokogiri document' do
-      request = described_class.new('')
-      expect(request.parse_xml('')).to be_a(Nokogiri::XML::Document)
-    end
-
-    it 'returns a Nokogiri document with namespaces removed' do
-      xml_with_namespace = <<~XMLDATA
-      <?xml version="1.0" encoding="utf-8"?>
-      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-        <soap:Body>
-          <GetAllOccupationsShortResponse xmlns="urn:ams.se:wsoccupation">
-            <OccupationsShort>
-              <OccupationShort>
-                <Id>718</Id>
-                <Name>Landskapsarkitekter och landskapsingenjörer</Name>
-              </OccupationShort>
-            </OccupationsShort>
-          </GetAllOccupationsShortResponse>
-        </soap:Body>
-      </soap:Envelope>
-      XMLDATA
-
-      request = described_class.new('')
-
-      document = request.parse_xml(xml_with_namespace)
-      result = document.css('Id').map(&:text)
-      expect(result).to eq(%w[718])
-    end
-  end
 end

--- a/spec/cassettes/Arbetsformedlingen_API_Client/_ads/handles_error_from_arbetsf_rmedlingen.yml
+++ b/spec/cassettes/Arbetsformedlingen_API_Client/_ads/handles_error_from_arbetsf_rmedlingen.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.arbetsformedlingen.se/af/v0/platsannonser/matchning?anstallningstyp&antalrader=1000&kommunid&lanid=1&nyckelord&omradeid&organisationsnummer&sida=9999&sokdatum&yrkesgruppid&yrkesid&yrkesomradeid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.arbetsformedlingen.se
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - sv
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:26:09 GMT
+      Server:
+      - WildFly/8
+      Www-Authenticate:
+      - Basic realm="CT"
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Powered-By:
+      - Undertow/1
+      Access-Control-Allow-Headers:
+      - X-JWT-Assertion, Origin, X-Requested-With, Content-Type, Accept
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '333'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, HEAD, PUT, POST, DELETE
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PGh0bWw+PGhlYWQ+PC9oZWFkPjxib2R5PiA8aDE+RXJyb3I8L2gxPkJlc2tyaXZuaW5nOiBGZWwgdmlkIGjDpG10bmluZyBhdiBhbm5vbnNsaXN0YSBtZWQgc8O2a2tyaXRlcmllcihsYW5pZDoxOyBsYW5kaWQ6OyBvbXJhZGVpZDo7IGtvbW11bmlkOjsgeXJrZXNpZDo7IHlya2VzZ3J1cHBpZDo7IHZhcmFrdGlnaGV0aWQ6OyB5cmtlc29tcmFkZWlkOjsgIG55Y2tlbG9yZDo7IHNpZGE6OTk5OTsgYW50YWxyYWRlcjoxMDAwKTxiciAvPlN0YXR1c2tvZDogSW50ZXJuYWwgU2VydmVyIEVycm9yPGJyIC8+VGl0ZWw6IEludGVybmFsIFNlcnZlciBFcnJvcjxiciAvPjwvYm9keT48L2h0bWw+
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:26:09 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Arbetsformedlingen_API_Client/_ads/returns_empty_list_when_no_results_are_found.yml
+++ b/spec/cassettes/Arbetsformedlingen_API_Client/_ads/returns_empty_list_when_no_results_are_found.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.arbetsformedlingen.se/af/v0/platsannonser/matchning?anstallningstyp&antalrader=100&kommunid=0780&lanid&nyckelord&omradeid&organisationsnummer&sida=23&sokdatum&yrkesgruppid&yrkesid&yrkesomradeid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.arbetsformedlingen.se
+      Content-Type:
+      - application/json
+      Accept-Language:
+      - sv
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 10 Sep 2018 13:07:40 GMT
+      Server:
+      - WildFly/8
+      Www-Authenticate:
+      - Basic realm="CT"
+      Cache-Control:
+      - no-transform, max-age=600
+      X-Powered-By:
+      - Undertow/1
+      Access-Control-Allow-Headers:
+      - X-JWT-Assertion, Origin, X-Requested-With, Content-Type, Accept
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept,Accept-Language
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '153'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, HEAD, PUT, POST, DELETE
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"matchningslista":{"antal_platsannonser":662,"antal_platsannonser_exakta":0,"antal_platsannonser_narliggande":0,"antal_platserTotal":0,"antal_sidor":7}}'
+    http_version: 
+  recorded_at: Mon, 10 Sep 2018 13:07:40 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
- All methods in `Client` now returns objects with a `#response` method, see [`Response`](https://github.com/buren/arbetsformedlingen/blob/standout-fix-key-not-found-matchningdata/lib/arbetsformedlingen/api/response.rb) class
- Refactor `SOAPRequest` to use the same `Response` object
- Improve method/class/module docs

@scmx thanks for your PR #10 ⭐️I applied the same approach to the other methods in `client` so all endpoints _should_ not crash and instead return an "empty" result object (that you can call `#response` on to get access to the raw response).

I really want to refactor the code around build the response, but that will have to be another PR (kinda featured creeped this one with doc changes).