### PR TITLE
Fix crashes when ad data doesn't contain some keys

### DIFF
--- a/lib/arbetsformedlingen/api/results/ad_result.rb
+++ b/lib/arbetsformedlingen/api/results/ad_result.rb
@@ -32,7 +32,7 @@ module Arbetsformedlingen
           total_vacancies: ad_data.fetch('antal_platser'),
           municipalities: ad_data.fetch('kommunnamn'),
           municipality_id: ad_data.fetch('kommunkod'),
-          total_vacancies_with_visa: ad_data.fetch('antalplatserVisa'),
+          total_vacancies_with_visa: ad_data.fetch('antalplatserVisa', nil),
           employment_type: ad_data.fetch('anstallningstyp'),
           terms: build_terms(data.fetch('villkor')),
           application: build_application(data.fetch('ansokan')),
@@ -71,7 +71,7 @@ module Arbetsformedlingen
           name: data.fetch('arbetsplatsnamn'),
           postal: build_postal(data),
           country: data.fetch('land'),
-          visit_address: data.fetch('besoksadress'),
+          visit_address: data.fetch('besoksadress', nil),
           logotype_url: data.fetch('logotypurl', nil),
           website: data.fetch('hemsida', nil),
           contacts: (
@@ -84,10 +84,10 @@ module Arbetsformedlingen
 
       def self.build_postal(data)
         Values::Postal.new(
-          code: data.fetch('postnummer'),
-          address: data.fetch('postadress'),
-          city: data.fetch('postort'),
-          country: data.fetch('postland')
+          code: data.fetch('postnummer', nil),
+          address: data.fetch('postadress', nil),
+          city: data.fetch('postort', nil),
+          country: data.fetch('postland', nil)
         )
       end
 

--- a/lib/arbetsformedlingen/api/results/matchning_result.rb
+++ b/lib/arbetsformedlingen/api/results/matchning_result.rb
@@ -71,7 +71,7 @@ module Arbetsformedlingen
           url: ad_data.fetch('annonsurl'),
           relevance: ad_data.fetch('relevans'),
           total_vacancies: ad_data.fetch('antalplatser'),
-          total_vacancies_with_visa: ad_data.fetch('antalPlatserVisa'),
+          total_vacancies_with_visa: ad_data.fetch('antalPlatserVisa', nil),
           duration_id: ad_data.fetch('varaktighetId', nil),
           counties: ad_data.fetch('lan'),
           country_id: ad_data.fetch('lanid'),


### PR DESCRIPTION
As mentioned here: https://github.com/buren/arbetsformedlingen/pull/11#issuecomment-420951486

We've gone through all ads now. Should be no further `KeyError`s left to fix. (Famous last words)